### PR TITLE
Add Deno KeyValue store

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "editor.defaultFormatter": "denoland.vscode-deno",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll": true
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,139 @@
+{
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@oak/commons@0.11": "jsr:@oak/commons@0.11.0",
+      "jsr:@std/assert@0.223": "jsr:@std/assert@0.223.0",
+      "jsr:@std/assert@0.226": "jsr:@std/assert@0.226.0",
+      "jsr:@std/assert@^0.223.0": "jsr:@std/assert@0.223.0",
+      "jsr:@std/assert@^0.224.0": "jsr:@std/assert@0.224.0",
+      "jsr:@std/bytes@0.223": "jsr:@std/bytes@0.223.0",
+      "jsr:@std/bytes@0.224": "jsr:@std/bytes@0.224.0",
+      "jsr:@std/bytes@^0.223.0": "jsr:@std/bytes@0.223.0",
+      "jsr:@std/crypto@0.223": "jsr:@std/crypto@0.223.0",
+      "jsr:@std/crypto@0.224": "jsr:@std/crypto@0.224.0",
+      "jsr:@std/encoding@1.0.0-rc.2": "jsr:@std/encoding@1.0.0-rc.2",
+      "jsr:@std/encoding@^0.223.0": "jsr:@std/encoding@0.223.0",
+      "jsr:@std/http@0.223": "jsr:@std/http@0.223.0",
+      "jsr:@std/http@0.224": "jsr:@std/http@0.224.5",
+      "jsr:@std/io@0.223": "jsr:@std/io@0.223.0",
+      "jsr:@std/media-types@0.223": "jsr:@std/media-types@0.223.0",
+      "jsr:@std/media-types@0.224": "jsr:@std/media-types@0.224.1",
+      "jsr:@std/path@0.223": "jsr:@std/path@0.223.0",
+      "npm:path-to-regexp@6.2.1": "npm:path-to-regexp@6.2.1"
+    },
+    "jsr": {
+      "@oak/commons@0.11.0": {
+        "integrity": "07702bfe5c07cd8144c422022994da1f9fea466b185824f4be63a2b1b1a65125",
+        "dependencies": [
+          "jsr:@std/assert@0.226",
+          "jsr:@std/bytes@0.224",
+          "jsr:@std/crypto@0.224",
+          "jsr:@std/http@0.224",
+          "jsr:@std/media-types@0.224"
+        ]
+      },
+      "@std/assert@0.223.0": {
+        "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
+      },
+      "@std/assert@0.224.0": {
+        "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
+      },
+      "@std/assert@0.226.0": {
+        "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
+      },
+      "@std/bytes@0.223.0": {
+        "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
+      },
+      "@std/bytes@0.224.0": {
+        "integrity": "a2250e1d0eb7d1c5a426f21267ab9bdeac2447fa87a3d0d1a467d3f7a6058e49"
+      },
+      "@std/crypto@0.223.0": {
+        "integrity": "1aa9555ff56b09e197ad988ea200f84bc6781fd4fd83f3a156ee44449af93000",
+        "dependencies": [
+          "jsr:@std/assert@^0.223.0",
+          "jsr:@std/encoding@^0.223.0"
+        ]
+      },
+      "@std/crypto@0.224.0": {
+        "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
+        "dependencies": [
+          "jsr:@std/assert@^0.224.0"
+        ]
+      },
+      "@std/encoding@0.223.0": {
+        "integrity": "2b5615a75e00337ce113f34cf2f9b8c18182c751a8dcc8b1a2c2fc0e117bef00"
+      },
+      "@std/encoding@1.0.0-rc.2": {
+        "integrity": "160d7674a20ebfbccdf610b3801fee91cf6e42d1c106dd46bbaf46e395cd35ef"
+      },
+      "@std/http@0.223.0": {
+        "integrity": "15ab8a0c5a7e9d5be017a15b01600f20f66602ceec48b378939fa24fcec522aa",
+        "dependencies": [
+          "jsr:@std/assert@^0.223.0",
+          "jsr:@std/encoding@^0.223.0"
+        ]
+      },
+      "@std/http@0.224.5": {
+        "integrity": "b03b5d1529f6c423badfb82f6640f9f2557b4034cd7c30655ba5bb447ff750a4",
+        "dependencies": [
+          "jsr:@std/encoding@1.0.0-rc.2"
+        ]
+      },
+      "@std/io@0.223.0": {
+        "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
+        "dependencies": [
+          "jsr:@std/bytes@^0.223.0"
+        ]
+      },
+      "@std/media-types@0.223.0": {
+        "integrity": "84684680c2eb6bc6d9369c6d6f26a49decaf2c7603ff531862dda575d9d6776e"
+      },
+      "@std/media-types@0.224.1": {
+        "integrity": "9e69a5daed37c5b5c6d3ce4731dc191f80e67f79bed392b0957d1d03b87f11e1"
+      },
+      "@std/path@0.223.0": {
+        "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
+        "dependencies": [
+          "jsr:@std/assert@^0.223.0"
+        ]
+      }
+    },
+    "npm": {
+      "path-to-regexp@6.2.1": {
+        "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+        "dependencies": {}
+      }
+    }
+  },
+  "remote": {
+    "https://deno.land/x/oak@v16.1.0/application.ts": "c6361a3c3fb3607c5dfe1800b156f07b612979dc0498c746aeca54bb9f643a92",
+    "https://deno.land/x/oak@v16.1.0/body.ts": "0f8a6843720ea6cebba2132a5e4dda5a97bbd49e7fb64e96ade0b7c8009bba2d",
+    "https://deno.land/x/oak@v16.1.0/context.ts": "a93a5b41dde2ceb52232ae31b3496be76e8a42ea421a73d7cffe9e640adb8dfd",
+    "https://deno.land/x/oak@v16.1.0/deps.ts": "f960515f71091adecc3df5e2295b3acfc4f1c003e08be29fceec1f7616053433",
+    "https://deno.land/x/oak@v16.1.0/http_server_bun.ts": "cb3a66c735cd0533c4c3776b37ae627ab42344c82f91dff63e3030d9656fd3a0",
+    "https://deno.land/x/oak@v16.1.0/http_server_native.ts": "3bea00ebb9638203d2449fbf9a14a6b87f119bd45012f13282ececdf7b4c4242",
+    "https://deno.land/x/oak@v16.1.0/http_server_native_request.ts": "a4da6f4939736e6323720db2d4b0d19ff2e83f02e52ab1eea9ae80f2c047fa56",
+    "https://deno.land/x/oak@v16.1.0/http_server_node.ts": "9bb5291c15305b297fd634aa4c6b1d5054368f4b7a171d7c7c302c73eb2489ed",
+    "https://deno.land/x/oak@v16.1.0/middleware.ts": "4170180fe5009d2581a0bdc995e5953b90ccb5b1c3767f3eae8a4fe238b8bd81",
+    "https://deno.land/x/oak@v16.1.0/middleware/etag.ts": "310ed4ed01f2af5384ab78617c82a2bdd7f84d66539172e45ee16452846f0754",
+    "https://deno.land/x/oak@v16.1.0/middleware/proxy.ts": "a0b4964509d4320735ffbe52ae2629c78e302dd9b934fcf2ddf189d491469892",
+    "https://deno.land/x/oak@v16.1.0/middleware/serve.ts": "efceebd70afb73bcabe0a6a8981f3d8474a2f2f30e85b46761aee49e81bd9d6a",
+    "https://deno.land/x/oak@v16.1.0/mod.ts": "38e53e01e609583e843f3e2b2677de9872d23d68939ce0de85b402e7a8db01a7",
+    "https://deno.land/x/oak@v16.1.0/node_shims.ts": "4db1569b2b79b73f37c4d947f4aaa50a93e266d48fe67601c8a31af17a28884d",
+    "https://deno.land/x/oak@v16.1.0/request.ts": "1e7f2c338cd6889b616bbdc9e2062eac27acbffde05c685adfb1c60ecc80682a",
+    "https://deno.land/x/oak@v16.1.0/response.ts": "bc47174d3d797ffc802f40fba006c16de8390e776a36f6f4a4d4f58b278bf36f",
+    "https://deno.land/x/oak@v16.1.0/router.ts": "882f36a576e280b0d617cc174feca320f02deed77bdea8264444ba8b55cc0422",
+    "https://deno.land/x/oak@v16.1.0/send.ts": "c05e5985b356b568ae4954a40373f93451a3f8cc9ae8706c8b8879e5e0c8c86b",
+    "https://deno.land/x/oak@v16.1.0/testing.ts": "c879789ac721144c3dcad0a06f5afbe2cd94fb20afc32302992942a49a7def90",
+    "https://deno.land/x/oak@v16.1.0/types.ts": "cd4ccd3e182d0cba2117cd27f560267970470ab9c0ff6556cadd73f605193be7",
+    "https://deno.land/x/oak@v16.1.0/utils/clone_state.ts": "cf8989ddd56816b36ada253ae0acdbd46cdf3d68dbe674d2b66c46640fab3500",
+    "https://deno.land/x/oak@v16.1.0/utils/consts.ts": "137c4f73479f5e98a13153b9305f06f0d85df3cf2aacad2c9f82d4c1f3a2f105",
+    "https://deno.land/x/oak@v16.1.0/utils/create_promise_with_resolvers.ts": "de99e9a998162b929a011f8873eaf0895cf4742492b3ce6f6866d39217342523",
+    "https://deno.land/x/oak@v16.1.0/utils/decode_component.ts": "d3e2c40ecdd2fdb79761c6e9ae224cf01a4643f7c5f4c1e0b69698d43025261b",
+    "https://deno.land/x/oak@v16.1.0/utils/encode_url.ts": "c0ed6b318eb9523adeebba32eb9acd059c0f94d3511b2b9e3b024722d1b3dfb8",
+    "https://deno.land/x/oak@v16.1.0/utils/resolve_path.ts": "aa39d54a003b38fee55f340a0cba3f93a7af85b8ddd5fbfb049a98fc0109b36d",
+    "https://deno.land/x/oak@v16.1.0/utils/streams.ts": "6d55543fdeddc3c9c6f512de227b9b33ff4b0ec5e320edc109f0cbf9bef8963f",
+    "https://deno.land/x/oak@v16.1.0/utils/type_guards.ts": "a1b42aa4c431c4c07d3f8a45a2142020f86d5a3e1e319af94fdf2f4c6c72465f"
+  }
+}

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export type {
   Context,
   Middleware,
-} from "https://deno.land/x/oak@v11.1.0/mod.ts";
+} from "https://deno.land/x/oak@v16.1.0/mod.ts";
 export { MapStore, Store } from "./src/stores/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,2 +1,2 @@
 export { RateLimiter } from "./src/ratelimit.ts";
-export { MapStore, Store } from "./src/stores/mod.ts";
+export { KeyValueStore, MapStore, Store } from "./src/stores/mod.ts";

--- a/src/stores/AbstractStore.ts
+++ b/src/stores/AbstractStore.ts
@@ -1,7 +1,7 @@
 import type { Ratelimit } from "../types/types.d.ts";
 
 export abstract class Store {
-  public init(): Promise<void> | void {
+  public init(_withUrl: boolean): Promise<void> | void {
     throw "Not implemented";
   }
 
@@ -9,14 +9,18 @@ export abstract class Store {
     throw "Not implemented";
   }
 
+  public setUrlKey(_url: URL): void {
+    throw "No implemented";
+  }
+
   public set(
     _ip: string,
-    _ratelimit: Ratelimit,
+    _ratelimit: Ratelimit
   ): Promise<Ratelimit> | Map<string, Ratelimit> {
     throw "Not implemented";
   }
 
-  public delete(_ip: string): Promise<boolean> | boolean {
+  public delete(_ip: string): Promise<boolean | void> | boolean {
     throw "Not implemented";
   }
 

--- a/src/stores/KeyValueStore.ts
+++ b/src/stores/KeyValueStore.ts
@@ -1,0 +1,64 @@
+import { Ratelimit } from "../types/types.d.ts";
+import { Store } from "./AbstractStore.ts";
+
+// Primary key prefix to store IPs in
+const STORE_KEY = "ratelimit";
+
+const getKey = (url: URL | null, ip: string): Deno.KvKey => {
+  if (url) {
+    return [STORE_KEY, url.toString(), ip];
+  }
+
+  return [STORE_KEY, ip];
+};
+
+export class KeyValueStore extends Store {
+  private withUrl: boolean = false;
+  private url: URL | null = null;
+
+  // Default key just has the prefix
+  constructor(private readonly store: Deno.Kv) {
+    super();
+  }
+
+  public init(withUrl: boolean) {
+    this.withUrl = withUrl;
+    return;
+  }
+
+  public setUrlKey(url: URL): void {
+    if (!this.withUrl) {
+      console.warn("options.withUrl is false, unable to update KV key.");
+      return;
+    }
+
+    this.url = url;
+  }
+
+  public async has(_ip: string): Promise<boolean> {
+    const entry = await this.store.get(getKey(this.url, _ip));
+    return !!entry.value;
+  }
+
+  public async get(_ip: string) {
+    const entry = await this.store.get(getKey(this.url, _ip));
+    return entry.value as Ratelimit;
+  }
+
+  /**
+   * @throws {Error} If the ratelimit is unable to be saved
+   */
+  public async set(_ip: string, _ratelimit: Ratelimit): Promise<Ratelimit> {
+    const result = await this.store.set(getKey(this.url, _ip), _ratelimit);
+
+    if (result.ok) {
+      return _ratelimit;
+    } else {
+      throw new Error("Unable to set ratelimit value");
+    }
+  }
+
+  public async delete(_ip: string): Promise<void> {
+    await this.store.delete(getKey(this.url, _ip));
+  }
+}

--- a/src/stores/mod.ts
+++ b/src/stores/mod.ts
@@ -1,2 +1,3 @@
 export * from "./AbstractStore.ts";
+export * from "./KeyValueStore.ts";
 export * from "./MapStore.ts";

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,4 +1,4 @@
-import { Context } from "../../deps.ts";
+import { Context } from "https://deno.land/x/oak@v16.1.0/context.ts";
 import { Store } from "../stores/AbstractStore.ts";
 
 export interface Ratelimit {
@@ -8,9 +8,8 @@ export interface Ratelimit {
 
 export interface RatelimitOptions {
   windowMs: number;
-  max: (
-    ctx: Context,
-  ) => Promise<number> | number;
+  max: (ctx: Context) => Promise<number> | number;
+  withUrl: boolean;
   store: Store;
   headers: boolean;
   message: string;
@@ -19,6 +18,6 @@ export interface RatelimitOptions {
   onRateLimit: (
     ctx: Context,
     next: () => Promise<unknown>,
-    opt: RatelimitOptions,
+    opt: RatelimitOptions
   ) => unknown;
 }

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -5,6 +5,7 @@ import { RatelimitOptions } from "../types/types.d.ts";
 export const DefaultOptions: RatelimitOptions = {
   windowMs: 60 * 1000,
   max: () => 100,
+  withUrl: false,
   store: new MapStore(),
   headers: true,
   message: "Too many requests, please try again later.",


### PR DESCRIPTION
This adds a store type to use Deno's KeyValue database. A new option is added called "withUrl" that interops with the KV store to track either the user across the app or on a per-route basis. This is helpful if I want to allow a lot of access to one route, but limit something like auth signups.